### PR TITLE
Add terrain ultra material support for 1.9

### DIFF
--- a/Assets/Shaders/SphereCloud.shader
+++ b/Assets/Shaders/SphereCloud.shader
@@ -209,7 +209,8 @@ Shader "EVE/Cloud" {
 					scolor *= Terminator(normalize(_WorldSpaceLightPos0), worldNormal);
 					scolor.a = transparency;
 #ifdef SOFT_DEPTH_ON
-					float depth = UNITY_SAMPLE_DEPTH(tex2Dproj(_CameraDepthTexture, UNITY_PROJ_COORD(IN.projPos)));
+					//float depth = UNITY_SAMPLE_DEPTH(tex2Dproj(_CameraDepthTexture, UNITY_PROJ_COORD(IN.projPos)));
+					float depth = SAMPLE_DEPTH_TEXTURE_PROJ(tex2Dproj(_CameraDepthTexture, UNITY_PROJ_COORD(IN.projPos))); // fixes clouds disappearing at ~150km height
 					depth = LinearEyeDepth(depth);
 					float partZ = IN.projPos.z;
 					float fade = saturate(_InvFade * (depth - partZ));

--- a/Terrain/TerrainPQS.cs
+++ b/Terrain/TerrainPQS.cs
@@ -22,7 +22,7 @@ namespace Terrain
         GameObject OceanBacking = null;
         Material OceanBackingMaterial;
         Material OceanSurfaceMaterial;
-        private Material pqsSurfaceMaterial;
+        Material pqsSurfaceMaterial;
 
         public override void OnSphereActive()
         {
@@ -231,6 +231,13 @@ namespace Terrain
                     if (pqs.highQualitySurfaceMaterial != null)
                     {
                         return pqs.highQualitySurfaceMaterial;
+                    }
+                    break;
+                // ultraQualitySurfaceMaterial support for 1.9
+                case 3:
+                    if (pqs.ultraQualitySurfaceMaterial != null)
+                    {
+                        return pqs.ultraQualitySurfaceMaterial;
                     }
                     break;
             }


### PR DESCRIPTION
Here is a small change to get terrain work on 1.9. It works on my end, so I think it ready for release when it comes out.

The one thing I've noticed - you've included my 'eveshaders.bundle' file into the current release, but I compiled it from the old WazWaz's code and you've done some changes to 'SphereCloud.shader'. I've recompiled it with your changes and didn't notice any problems. I think we'll replace it too with the next release?